### PR TITLE
BUG: Fix problem with Scipy.integrate.solve_bvp for big problems

### DIFF
--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -143,13 +143,9 @@ def compute_jac_indices(n, m, k):
 def stacked_matmul(a, b):
     """Stacked matrix multiply: out[i,:,:] = np.dot(a[i,:,:], b[i,:,:]).
 
-    In our case, a[i, :, :] and b[i, :, :] are square unless parameters are included in the dependent variables,
-    i.e. if the calling signature for fun in scipy.integrate.solve_bvp is fun(x, y, p) vs. fun(x, y). If parameters
-    are present, then a[] will be a non-square matrix.
-
+    Empirical optimization. Use outer Python loop and BLAS for large
+    matrices, otherwise use a single einsum call.
     """
-    # Empirical optimization. Use outer Python loop and BLAS for large
-    # matrices, otherwise use a single einsum call.
     if a.shape[1] > 50:
         out = np.empty((a.shape[0], a.shape[1], b.shape[2]))
         for i in range(a.shape[0]):

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -153,8 +153,8 @@ def big_sol(x, n):
 
 
 def big_fun_with_parameters(x, y, p):
-    """
-    big version of sl_fun, with two parameters.
+    """ Big version of sl_fun, with two parameters.
+
     The two differential equations represented by sl_fun are broadcast to the number of rows of y, rotating between the
     parameters p[0] and p[1].
     Here are the differential equations:
@@ -205,9 +205,8 @@ def big_bc_with_parameters_jac(ya, yb, p):
     dbc_dya = np.zeros((n + 2, n))
     dbc_dyb = np.zeros((n + 2, n))
 
-    n_by_2 = int(n / 2)
-    dbc_dya[range(n_by_2), range(0, n, 2)] = 1
-    dbc_dyb[range(n_by_2, n), range(0, n, 2)] = 1
+    dbc_dya[range(n // 2), range(0, n, 2)] = 1
+    dbc_dyb[range(n // 2, n), range(0, n, 2)] = 1
 
     dbc_dp = np.zeros((n + 2, 2))
     dbc_dp[n, 0] = -1
@@ -623,7 +622,7 @@ def test_big_problem_with_parameters():
 
             for isol in range(0, n, 4):
                 assert_allclose(sol_test[isol], big_sol_with_parameters(x_test, [1, 1])[0],
-                            rtol=1e-4, atol=1e-4)
+                                rtol=1e-4, atol=1e-4)
                 assert_allclose(sol_test[isol + 2], big_sol_with_parameters(x_test, [1, 1])[1],
                                 rtol=1e-4, atol=1e-4)
 


### PR DESCRIPTION

This commit solves fatal errors when solve_bvp is used for a big problem, i.e. size > 50,
and the unknowns include parameters that need solving.
This commit includes tests, with and without Jacobians for both the function and the boundary conditions.
The new tests adapt already existing tests to make them easier to compare and understand.

update: made improvements recommended by nmayorov
